### PR TITLE
98 first question is appearing before start quiz button is hit

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -101,6 +101,7 @@ function showTimeUpModal() {
   const timeUpModal = new bootstrap.Modal(timeUpModalEl); // Initialize the Bootstrap modal
   timeUpModal.show(); // Show the modal
 }
+
 let questionData = quizData[currentQuestionIndex];
 // Function to render the current question when the start quiz button is clicked
 //the loadQuestion function dynamically generates

--- a/assets/script.js
+++ b/assets/script.js
@@ -149,6 +149,8 @@ startBtn.addEventListener("click", function () {
   startTimer();
   // loads the first question
   loadQuiz(quizData[currentQuestionIndex]);
+  // display question when start-quiz button is hit
+  document.getElementById("quiz-container").style.display = "block";
   // display next question button
   document.getElementById("next-question").style.display = "block";
 });

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -69,10 +69,6 @@ div.form-check.form-switch {
   text-align: left;
 }
 
-.timer {
-  display: none;
-}
-
 #feedback {
   border: 1px solid black;
   width: 47%;

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -90,4 +90,5 @@ div.form-check.form-switch {
 }
 
 #next-question {
+  display: none;
 }

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -92,3 +92,7 @@ div.form-check.form-switch {
 #next-question {
   display: none;
 }
+
+#quiz-container {
+  display: none;
+}

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -69,6 +69,10 @@ div.form-check.form-switch {
   text-align: left;
 }
 
+.timer {
+  display: none;
+}
+
 #feedback {
   border: 1px solid black;
   width: 47%;


### PR DESCRIPTION
# What was changed
- [ ] css was added to hide the next-question button before the start-button is hit.
![image](https://github.com/user-attachments/assets/935d4731-a67e-4fb5-bb78-d17c92fb2a16)

- [ ] a getElementById was added to the startBtn event listener to display the next-question button after the start-button is hit.
![image](https://github.com/user-attachments/assets/80a0e4e2-6343-4372-9642-8ba520d68ef1)

- [ ] css was added to hide the question before the start-button is hit.
![image](https://github.com/user-attachments/assets/3c6391d8-d9a2-486d-8193-b33d6d8d878c)

- [ ] a getElementById was added to the startBtn event listener to display the question after the start-button is hit.
![image](https://github.com/user-attachments/assets/50453397-262a-47ff-85b2-c7145cc5bc7e)

# What you should see in the app
## Before the start button is hit (in light mode)
![image](https://github.com/user-attachments/assets/17366931-bbd4-4c2f-b762-fb2146ace7a4)

## Before the start button is hit (in dark mode)
![image](https://github.com/user-attachments/assets/01acde84-d96b-4bec-b157-bef14b536de0)

## After the start button is hit (in light mode)
![image](https://github.com/user-attachments/assets/607124cb-25bf-44f5-b929-727dea7ff434)

## After the start button is hit (in dark mode)
![image](https://github.com/user-attachments/assets/00c44d7a-80cc-4e53-acbb-807442b922db)

