### PR TITLE
127 user score after each ques is not displaying

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -170,6 +170,7 @@ function nextQuestion() {
     feedbackEl.innerHTML = "Correct";
     feedbackEl.style.color = "green";
     userScore++;
+    scoreBoardEl.textContent = `Score: ${userScore}`;
   } else {
     feedbackEl.innerHTML = "Incorrect";
     feedbackEl.style.color = "red";


### PR DESCRIPTION
# Changes made
- [ ] added code to the nextQuestion function to display the current score after each question
![image](https://github.com/user-attachments/assets/a6abda7a-440b-44ef-889b-96b9121c6ff0) 

# What you should see on the app
## Score update after answering the first question correctly (in light mode).
![image](https://github.com/user-attachments/assets/0c2b0430-9031-40db-8f2d-4c15e7c88d13)

## Score update after answering question 1 and 2 correctly, then answering question 3 incorrectly (in dark mode).
![image](https://github.com/user-attachments/assets/c6ce7d42-ae54-444b-8e4d-3c5142abd57b)

